### PR TITLE
Basic peer scoring

### DIFF
--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -31,6 +31,8 @@ pub(super) struct Config {
     /// The maximum number of consecutive times we'll allow the network component to return an
     /// empty set of fully-connected peers before we give up.
     max_retries_while_not_connected: u64,
+    /// How many fetches in between attempting to redeem one bad node.
+    pub(crate) redemption_interval: u32,
 }
 
 impl Config {
@@ -50,6 +52,7 @@ impl Config {
             retry_interval: Duration::from_millis(node_config.retry_interval.millis()),
             sync_to_genesis: node_config.sync_to_genesis,
             max_retries_while_not_connected,
+            redemption_interval: 10_000,
         }
     }
 

--- a/node/src/components/chain_synchronizer/config.rs
+++ b/node/src/components/chain_synchronizer/config.rs
@@ -52,7 +52,7 @@ impl Config {
             retry_interval: Duration::from_millis(node_config.retry_interval.millis()),
             sync_to_genesis: node_config.sync_to_genesis,
             max_retries_while_not_connected,
-            redemption_interval: 10_000,
+            redemption_interval: node_config.sync_peer_redemption_interval,
         }
     }
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -73,6 +73,7 @@ struct ChainSyncContext<'a> {
     metrics: &'a Metrics,
     /// A list of peers which should be asked for data in the near future.
     bad_peer_list: RwLock<VecDeque<NodeId>>,
+    /// Number of times peer lists have been filtered.
     filter_count: AtomicI64,
 }
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -184,7 +184,10 @@ impl<'a> ChainSyncContext<'a> {
 
         let bad_peer_list = mem::take::<VecDeque<NodeId>>(&mut bad_peer_list);
         if !bad_peer_list.is_empty() {
-            warn!(?bad_peer_list, "redeemed all bad peers")
+            warn!(
+                bad_peer_count = bad_peer_list.len(),
+                "redeemed all bad peers"
+            )
         }
     }
 }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -184,7 +184,7 @@ impl<'a> ChainSyncContext<'a> {
 
         let bad_peer_list = mem::take::<VecDeque<NodeId>>(&mut bad_peer_list);
         if !bad_peer_list.is_empty() {
-            warn!(?bad_peer_list, "ran out of peers, redeemed all bad peers")
+            warn!(?bad_peer_list, "redeemed all bad peers")
         }
     }
 }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -167,9 +167,9 @@ impl<'a> ChainSyncContext<'a> {
 
         // Note: Like `filter_bad_peers`, this may need to be migrated to use sets instead.
         if bad_peer_list.contains(&peer) {
-            bad_peer_list.push_back(peer);
             info!(%peer, "peer already marked as bad for syncing");
         } else {
+            bad_peer_list.push_back(peer);
             info!(%peer, "marked peer as bad for syncing");
         }
     }

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -144,7 +144,9 @@ impl<'a> ChainSyncContext<'a> {
         }
 
         let redemption_interval = self.config.redemption_interval as i64;
-        if self.filter_count.fetch_add(1, Ordering::Relaxed) > redemption_interval {
+        if redemption_interval != 0
+            && self.filter_count.fetch_add(1, Ordering::Relaxed) > redemption_interval
+        {
             self.filter_count
                 .fetch_sub(redemption_interval, Ordering::Relaxed);
 

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -7,6 +7,7 @@ use crate::types::{BlockHash, TimeDiff};
 const DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES: u32 = 20;
 /// Maximum number of tries to fetch in parallel, by default.
 const DEFAULT_MAX_PARALLEL_TRIE_FETCHES: u32 = 20;
+const DEFAULT_PEER_REDEMPTION_INTERVAL: u32 = 10_000;
 const DEFAULT_RETRY_INTERVAL: &str = "100ms";
 
 /// Node fast-sync configuration.
@@ -26,6 +27,9 @@ pub struct NodeConfig {
     /// The duration for which to pause between retry attempts while synchronising during joining.
     pub retry_interval: TimeDiff,
 
+    /// How many items to fetch before redeeming a random peer.
+    pub sync_peer_redemption_interval: u32,
+
     /// Whether to run in sync-to-genesis mode which captures all data (blocks, deploys
     /// and global state) back to genesis.
     pub sync_to_genesis: bool,
@@ -38,6 +42,7 @@ impl Default for NodeConfig {
             max_parallel_deploy_fetches: DEFAULT_MAX_PARALLEL_DEPLOY_FETCHES,
             max_parallel_trie_fetches: DEFAULT_MAX_PARALLEL_TRIE_FETCHES,
             retry_interval: DEFAULT_RETRY_INTERVAL.parse().unwrap(),
+            sync_peer_redemption_interval: DEFAULT_PEER_REDEMPTION_INTERVAL,
             sync_to_genesis: false,
         }
     }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -15,6 +15,9 @@ max_parallel_trie_fetches = 20
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'
 
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
 # Whether to synchronize all data back to genesis when joining.
 sync_to_genesis = true
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -15,6 +15,9 @@ max_parallel_trie_fetches = 20
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'
 
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
 # Whether to synchronize all data back to genesis when joining.
 sync_to_genesis = true
 

--- a/utils/nctl/sh/scenarios/configs/bond_its.config.toml
+++ b/utils/nctl/sh/scenarios/configs/bond_its.config.toml
@@ -15,6 +15,9 @@ max_parallel_trie_fetches = 20
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'
 
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
 # Whether to synchronize all data back to genesis when joining.
 sync_to_genesis = true
 

--- a/utils/nctl/sh/scenarios/configs/gov96.config.toml
+++ b/utils/nctl/sh/scenarios/configs/gov96.config.toml
@@ -19,6 +19,9 @@ max_parallel_trie_fetches = 20
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'
 
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
 # Whether to synchronize all data back to genesis when joining.
 sync_to_genesis = true
 

--- a/utils/nctl/sh/scenarios/configs/itst13.config.toml
+++ b/utils/nctl/sh/scenarios/configs/itst13.config.toml
@@ -15,6 +15,9 @@ max_parallel_trie_fetches = 20
 # The duration for which to pause between retry attempts while synchronising during joining.
 retry_interval = '100ms'
 
+# How often between sync attempts to redeem a bad node.
+sync_peer_redemption_interval = 10_000
+
 # Whether to synchronize all data back to genesis when joining.
 sync_to_genesis = true
 


### PR DESCRIPTION
Implements a basic system that will prefer to ask peers for data that previously provided some by keeping a list of offenders called "bad peers". If a peer times out or reports as not having data available, it is marked bad and not asked for data anymore.

Every 10k download attempts (this number is configurable) the old bad peer will be redeemed, i.e. removed from the bad list, giving it a chance to be included in the next round of downloads. Should the node run out of peers entirely, all bad peers will be redeemed immediately.

A refactoring of passing the context around in more functions was necessary. This hit a little hiccup at the beginning of the process, since the trusted hash is part of the context, but also fetched using functions that require it. It is left to the user of the struct to ensure that the trusted hash will not be accessed prematurely to avoid a panic.
