### PR TITLE
Optimize `descendant_trie_keys`

### DIFF
--- a/execution_engine/src/storage/global_state/lmdb.rs
+++ b/execution_engine/src/storage/global_state/lmdb.rs
@@ -317,8 +317,8 @@ impl StateProvider for LmdbGlobalState {
                 trie_keys.clone(),
                 &self
                     .digests_without_missing_descendants
-                    .write()
-                    .expect("digest cache write lock"),
+                    .read()
+                    .expect("digest cache read lock"),
             )?;
             if missing_descendants.is_empty() {
                 // There were no missing descendants on `trie_keys`, let's add them *and all of

--- a/execution_engine/src/storage/global_state/lmdb.rs
+++ b/execution_engine/src/storage/global_state/lmdb.rs
@@ -332,7 +332,15 @@ impl StateProvider for LmdbGlobalState {
                     lmdb::RoTransaction,
                     LmdbTrieStore,
                     Self::Error,
-                >(&txn, self.trie_store.deref(), trie_keys)?);
+                >(
+                    &txn,
+                    self.trie_store.deref(),
+                    trie_keys,
+                    &self
+                        .digests_without_missing_descendants
+                        .read()
+                        .expect("digest cache read lock"),
+                )?);
 
                 self.digests_without_missing_descendants
                     .write()

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -317,6 +317,7 @@ pub fn descendant_trie_keys<K, V, T, S, E>(
     txn: &T,
     store: &S,
     mut trie_keys_to_visit: Vec<Digest>,
+    known_complete: &HashSet<Digest>,
 ) -> Result<HashSet<Digest>, E>
 where
     K: ToBytes + FromBytes + Eq + std::fmt::Debug,
@@ -331,6 +332,11 @@ where
 
     while let Some(trie_key) = trie_keys_to_visit.pop() {
         if !visited.insert(trie_key) {
+            continue;
+        }
+
+        if known_complete.contains(&trie_key) {
+            // Skip because we know there are no missing descendants.
             continue;
         }
 

--- a/node/src/components/chain_synchronizer/operations.rs
+++ b/node/src/components/chain_synchronizer/operations.rs
@@ -858,8 +858,12 @@ async fn sync_to_genesis(ctx: &ChainSyncContext<'_>) -> Result<(KeyBlockInfo, Bl
 
     fetch_to_genesis(&trusted_block, ctx).await?;
 
+    info!("finished synchronization to genesis");
+
     // Sync forward until we are at the current version.
     let most_recent_block = fetch_forward(trusted_block, &mut trusted_key_block_info, ctx).await?;
+
+    info!("finished fetching forward");
 
     Ok((trusted_key_block_info, most_recent_block.take_header()))
 }


### PR DESCRIPTION
Uses the same trick as in `missing_trie_keys`: we pass in the _"tries known to have no missing descendants"_ cache to the `descendant_trie_keys` and if we reach a trie node that is in that cache, we short circuit. If a trie is in that cache, it means it must know about all of its descendants.