### PR TITLE
Event size reduction pr

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get stable from rust-toolchain.toml
         id: stable-toolchain
-        run: echo "::set-output name=version::$(grep -Eo '[0-9]+\.[0-9]+\.?[0-9]*' rust-toolchain.toml)"
+        run: echo "::set-output name=version::$(sed -nr 's/channel\s+=\s+\"(.*)\"/\1/p' rust-toolchain.toml)"
 
       - name: Install Toolchain - Stable
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #tag v1.0.7

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -36,11 +36,15 @@ jobs:
         id: nightly-toolchain
         run: echo "::set-output name=version::$(cat smart_contracts/rust-toolchain)"
 
+      - name: Get stable from rust-toolchain.toml
+        id: stable-toolchain
+        run: echo "::set-output name=version::$(shell grep -Eo '[0-9]+\.[0-9]+\.?[0-9]*' rust-toolchain.toml)"
+
       - name: Install Toolchain - Stable
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #tag v1.0.7
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ steps.stable-toolchain.outputs.version }}
           components: rustfmt, clippy
           target: wasm32-unknown-unknown
 

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get stable from rust-toolchain.toml
         id: stable-toolchain
-        run: echo "::set-output name=version::$(shell grep -Eo '[0-9]+\.[0-9]+\.?[0-9]*' rust-toolchain.toml)"
+        run: echo "::set-output name=version::$(grep -Eo '[0-9]+\.[0-9]+\.?[0-9]*' rust-toolchain.toml)"
 
       - name: Install Toolchain - Stable
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #tag v1.0.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.7"
+version = "1.4.8"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "tempfile",
  "wabt",
  "wasmi",
+ "wat",
 ]
 
 [[package]]
@@ -2549,6 +2550,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -5314,6 +5321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d443c5a7daae71697d97ec12ad70b4fe8766d3a0f4db16158ac8b781365892f7"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasmi"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,6 +5351,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
 dependencies = [
  "parity-wasm",
+]
+
+[[package]]
+name = "wast"
+version = "46.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0ab19660e3ea6891bba69167b9be40fad00fb1fe3dd39c5eebcee15607131b"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f775282def4d5bffd94d60d6ecd57bfe6faa46171cdbf8d32bd5458842b1e3e"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ RUSTUP = $(or $(shell which rustup), $(HOME)/.cargo/bin/rustup)
 NPM    = $(or $(shell which npm),    /usr/bin/npm)
 
 PINNED_NIGHTLY := $(shell cat smart_contracts/rust-toolchain)
+PINNED_STABLE  := $(shell grep -Eo '[0-9]+\.[0-9]+\.?[0-9]*' rust-toolchain.toml)
 
 CARGO_OPTS := --locked
 CARGO_PINNED_NIGHTLY := $(CARGO) +$(PINNED_NIGHTLY) $(CARGO_OPTS)
@@ -202,8 +203,8 @@ setup-audit:
 .PHONY: setup-rs
 setup-rs: smart_contracts/rust-toolchain
 	$(RUSTUP) update
-	$(RUSTUP) toolchain install stable $(PINNED_NIGHTLY)
-	$(RUSTUP) target add --toolchain stable wasm32-unknown-unknown
+	$(RUSTUP) toolchain install $(PINNED_STABLE) $(PINNED_NIGHTLY)
+	$(RUSTUP) target add --toolchain $(PINNED_STABLE) wasm32-unknown-unknown
 	$(RUSTUP) target add --toolchain $(PINNED_NIGHTLY) wasm32-unknown-unknown
 
 .PHONY: setup-nightly-rs

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RUSTUP = $(or $(shell which rustup), $(HOME)/.cargo/bin/rustup)
 NPM    = $(or $(shell which npm),    /usr/bin/npm)
 
 PINNED_NIGHTLY := $(shell cat smart_contracts/rust-toolchain)
-PINNED_STABLE  := $(shell grep -Eo '[0-9]+\.[0-9]+\.?[0-9]*' rust-toolchain.toml)
+PINNED_STABLE  := $(shell sed -nr 's/channel\s+=\s+\"(.*)\"/\1/p' rust-toolchain.toml)
 
 CARGO_OPTS := --locked
 CARGO_PINNED_NIGHTLY := $(CARGO) +$(PINNED_NIGHTLY) $(CARGO_OPTS)

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -27,6 +27,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 2.0.1
+
+### Security
+* Implement checks before preprocessing Wasm to avoid potential OOM when initializing table section.
+
+
+
 ## 2.0.0 - 2022-05-11
 
 ### Changed

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Security
 * Implement checks before preprocessing Wasm to avoid potential OOM when initializing table section.
-
+* Implement checks before preprocessing Wasm to avoid references to undeclared functions or globals.
 
 
 ## 2.0.0 - 2022-05-11

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Security
 * Implement checks before preprocessing Wasm to avoid potential OOM when initializing table section.
 * Implement checks before preprocessing Wasm to avoid references to undeclared functions or globals.
+* Implement checks before preprocessing Wasm to avoid possibility to import internal host functions.
 
 
 ## 2.0.0 - 2022-05-11

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "2.0.1" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."

--- a/execution_engine/src/core.rs
+++ b/execution_engine/src/core.rs
@@ -4,7 +4,7 @@ pub mod execution;
 pub mod resolvers;
 pub mod runtime;
 pub mod runtime_context;
-pub(crate) mod tracking_copy;
+pub mod tracking_copy;
 
 pub use tracking_copy::{validate_balance_proof, validate_query_proof, ValidationError};
 

--- a/execution_engine/src/core/tracking_copy/ext.rs
+++ b/execution_engine/src/core/tracking_copy/ext.rs
@@ -12,17 +12,19 @@ use crate::{
     storage::{global_state::StateReader, trie::merkle_proof::TrieMerkleProof},
 };
 
+/// Higher-level operations on the state via a `TrackingCopy`.
 pub trait TrackingCopyExt<R> {
+    /// The type for the returned errors.
     type Error;
 
-    /// Gets the account at a given account address
+    /// Gets the account at a given account address.
     fn get_account(
         &mut self,
         correlation_id: CorrelationId,
         account_hash: AccountHash,
     ) -> Result<Account, Self::Error>;
 
-    /// Reads the account at a given account address
+    /// Reads the account at a given account address.
     fn read_account(
         &mut self,
         correlation_id: CorrelationId,
@@ -30,55 +32,56 @@ pub trait TrackingCopyExt<R> {
     ) -> Result<Account, Self::Error>;
 
     // TODO: make this a static method
-    /// Gets the purse balance key for a given purse id
+    /// Gets the purse balance key for a given purse id.
     fn get_purse_balance_key(
         &self,
         correlation_id: CorrelationId,
         purse_key: Key,
     ) -> Result<Key, Self::Error>;
 
-    /// Gets the balance at a given balance key
+    /// Gets the balance at a given balance key.
     fn get_purse_balance(
         &self,
         correlation_id: CorrelationId,
         balance_key: Key,
     ) -> Result<Motes, Self::Error>;
 
-    /// Gets the purse balance key for a given purse id and provides a Merkle proof
+    /// Gets the purse balance key for a given purse id and provides a Merkle proof.
     fn get_purse_balance_key_with_proof(
         &self,
         correlation_id: CorrelationId,
         purse_key: Key,
     ) -> Result<(Key, TrieMerkleProof<Key, StoredValue>), Self::Error>;
 
-    /// Gets the balance at a given balance key and provides a Merkle proof
+    /// Gets the balance at a given balance key and provides a Merkle proof.
     fn get_purse_balance_with_proof(
         &self,
         correlation_id: CorrelationId,
         balance_key: Key,
     ) -> Result<(Motes, TrieMerkleProof<Key, StoredValue>), Self::Error>;
 
-    /// Gets a contract by Key
+    /// Gets a contract by Key.
     fn get_contract_wasm(
         &mut self,
         correlation_id: CorrelationId,
         contract_wasm_hash: ContractWasmHash,
     ) -> Result<ContractWasm, Self::Error>;
 
-    /// Gets a contract header by Key
+    /// Gets a contract header by Key.
     fn get_contract(
         &mut self,
         correlation_id: CorrelationId,
         contract_hash: ContractHash,
     ) -> Result<Contract, Self::Error>;
 
-    /// Gets a contract package by Key
+    /// Gets a contract package by Key.
     fn get_contract_package(
         &mut self,
         correlation_id: CorrelationId,
         contract_package_hash: ContractPackageHash,
     ) -> Result<ContractPackage, Self::Error>;
 
+    /// Gets the system contract registry.
     fn get_system_contracts(
         &mut self,
         correlation_id: CorrelationId,

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -1,3 +1,6 @@
+//! This module defines the `TrackingCopy` - a utility that caches operations on the state, so that
+//! the underlying state remains unmodified, but it can be interacted with as if the modifications
+//! were applied on it.
 mod byte_size;
 mod ext;
 pub(self) mod meter;
@@ -32,16 +35,24 @@ use crate::{
     storage::{global_state::StateReader, trie::merkle_proof::TrieMerkleProof},
 };
 
+/// Result of a query on a `TrackingCopy`.
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum TrackingCopyQueryResult {
+    /// The query was successful.
     Success {
+        /// The value read from the state.
         value: StoredValue,
+        /// Merkle proofs for the value.
         proofs: Vec<TrieMerkleProof<Key, StoredValue>>,
     },
+    /// The value wasn't found.
     ValueNotFound(String),
+    /// A circular reference was found in the state while traversing it.
     CircularReference(String),
+    /// The query reached the depth limit.
     DepthLimit {
+        /// The depth reached.
         depth: u64,
     },
 }
@@ -199,26 +210,36 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
         self.reads_cached.get_refresh(key).map(|v| &*v)
     }
 
+    /// Gets the set of mutated keys in the cache by `KeyTag`.
     pub fn get_key_tag_muts_cached(&mut self, key_tag: &KeyTag) -> Option<&BTreeSet<Key>> {
         self.key_tag_muts_cached.get(key_tag)
     }
 
+    /// Gets the set of read keys in the cache by `KeyTag`.
     pub fn get_key_tag_reads_cached(&mut self, key_tag: &KeyTag) -> Option<&BTreeSet<Key>> {
         self.key_tag_reads_cached.get_refresh(key_tag).map(|v| &*v)
     }
 }
 
+/// An interface for the global state that caches all operations (reads and writes) instead of
+/// applying them directly to the state. This way the state remains unmodified, while the user can
+/// interact with it as if it was being modified in real time.
 pub struct TrackingCopy<R> {
     reader: R,
     cache: TrackingCopyCache<HeapSize>,
     journal: ExecutionJournal,
 }
 
+/// Result of executing an "add" operation on a value in the state.
 #[derive(Debug)]
 pub enum AddResult {
+    /// The operation was successful.
     Success,
+    /// The key was not found.
     KeyNotFound(Key),
+    /// There was a type mismatch between the stored value and the value being added.
     TypeMismatch(StoredValueTypeMismatch),
+    /// Serialization error.
     Serialization(bytesrepr::Error),
 }
 
@@ -236,7 +257,8 @@ impl From<CLValueError> for AddResult {
 }
 
 impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
-    pub(super) fn new(reader: R) -> TrackingCopy<R> {
+    /// Creates a new `TrackingCopy` using the `reader` as the interface to the state.
+    pub fn new(reader: R) -> TrackingCopy<R> {
         TrackingCopy {
             reader,
             cache: TrackingCopyCache::new(1024 * 16, HeapSize),
@@ -247,6 +269,7 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         }
     }
 
+    /// Returns the `reader` used to access the state.
     pub fn reader(&self) -> &R {
         &self.reader
     }
@@ -263,7 +286,7 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
     /// `TrackingCopy`. this means the current usage requires repeated
     /// forking, however we recognize this is sub-optimal and will revisit
     /// in the future.
-    pub(super) fn fork(&self) -> TrackingCopy<&TrackingCopy<R>> {
+    pub fn fork(&self) -> TrackingCopy<&TrackingCopy<R>> {
         TrackingCopy::new(self)
     }
 
@@ -283,7 +306,8 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         }
     }
 
-    pub(super) fn get_keys(
+    /// Gets the set of keys in the state whose tag is `key_tag`.
+    pub fn get_keys(
         &mut self,
         correlation_id: CorrelationId,
         key_tag: &KeyTag,
@@ -306,7 +330,8 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         Ok(ret)
     }
 
-    pub(super) fn read(
+    /// Reads the value stored under `key`.
+    pub fn read(
         &mut self,
         correlation_id: CorrelationId,
         key: &Key,
@@ -320,7 +345,9 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         }
     }
 
-    pub(super) fn write(&mut self, key: Key, value: StoredValue) {
+    /// Writes `value` under `key`. Note that the write is only cached, and the global state itself
+    /// remains unmodified.
+    pub fn write(&mut self, key: Key, value: StoredValue) {
         let normalized_key = key.normalize();
         self.cache.insert_write(normalized_key, value.clone());
         self.journal.push((normalized_key, Transform::Write(value)));
@@ -330,7 +357,7 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
     /// Ok(Some(unit)) represents successful operation.
     /// Err(error) is reserved for unexpected errors when accessing global
     /// state.
-    pub(super) fn add(
+    pub fn add(
         &mut self,
         correlation_id: CorrelationId,
         key: Key,
@@ -402,11 +429,13 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
         }
     }
 
-    pub(super) fn effect(&self) -> ExecutionEffect {
+    /// Returns the execution effects cached by this instance.
+    pub fn effect(&self) -> ExecutionEffect {
         ExecutionEffect::from(self.journal.clone())
     }
 
-    pub(super) fn execution_journal(&self) -> ExecutionJournal {
+    /// Returns the journal of operations executed on this instance.
+    pub fn execution_journal(&self) -> ExecutionJournal {
         self.journal.clone()
     }
 
@@ -417,7 +446,7 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
     /// The intent is that `query()` is only used to satisfy `QueryRequest`s made to the server.
     /// Other EE internal use cases should call `read()` or `get()` in order to retrieve cached
     /// values.
-    pub(super) fn query(
+    pub fn query(
         &self,
         correlation_id: CorrelationId,
         config: &EngineConfig,

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/2.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/2.0.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -70,6 +70,12 @@ enum WasmValidationError {
     /// Module tries to import a function that the host does not provide.
     #[error("module imports a non-existent function")]
     MissingHostFunction,
+    /// Opcode for a global access refers to a non-existing global
+    #[error("opcode for a global access refers to non-existing global index {index}")]
+    IncorrectGlobalOperation {
+        /// Provided index.
+        index: u32,
+    },
 }
 
 /// An error emitted by the Wasm preprocessor.
@@ -268,6 +274,8 @@ pub fn preprocess(
 ) -> Result<Module, PreprocessingError> {
     let module = deserialize(module_bytes)?;
 
+    ensure_valid_access(&module)?;
+
     if memory_section(&module).is_none() {
         // `pwasm_utils::externalize_mem` expects a non-empty memory section to exist in the module,
         // and panics otherwise.
@@ -290,6 +298,35 @@ pub fn preprocess(
     let module = stack_height::inject_limiter(module, wasm_config.max_stack_height)
         .map_err(|_| PreprocessingError::StackLimiter)?;
     Ok(module)
+}
+
+fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
+    let code_section = if let Some(type_section) = module.code_section() {
+        type_section
+    } else {
+        return Ok(());
+    };
+
+    let global_len = module
+        .global_section()
+        .map(|global_section| global_section.entries().len())
+        .unwrap_or(0);
+
+    for instr in code_section
+        .bodies()
+        .iter()
+        .flat_map(|body| body.code().elements())
+    {
+        match instr {
+            Instruction::GetGlobal(idx) | Instruction::SetGlobal(idx)
+                if *idx as usize >= global_len =>
+            {
+                return Err(WasmValidationError::IncorrectGlobalOperation { index: *idx })
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 /// Returns a parity Module from the given bytes without making modifications or checking limits.

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -79,7 +79,7 @@ fn table_section(module: &mut Module) -> Option<&mut TableSection> {
 fn validate_table_section(mut module: Module) -> Result<Module, &'static str> {
     if let Some(sect) = table_section(&mut module) {
         for (i, table_entry) in sect.entries_mut().iter_mut().enumerate() {
-            if i > 1 {
+            if i >= 1 {
                 return Err("the number of tables must be at most one");
             }
 

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -8,6 +8,9 @@ use thiserror::Error;
 use super::wasm_config::WasmConfig;
 
 const DEFAULT_GAS_MODULE_NAME: &str = "env";
+/// Name of the internal gas function injected by [`pwasm_utils::inject_gas_counter`].
+const INTERNAL_GAS_FUNCTION_NAME: &str = "gas";
+
 /// We only allow maximum of 4k function pointers in a table section.
 pub const DEFAULT_MAX_TABLE_SIZE: u32 = 4096;
 /// Maximum number of elements that can appear as immediate value to the br_table instruction.
@@ -19,7 +22,8 @@ pub const DEFAULT_MAX_PARAMETER_COUNT: u32 = 256;
 
 /// An error emitted by the Wasm preprocessor.
 #[derive(Debug, Clone, Error)]
-pub enum WasmValidationError {
+#[non_exhaustive]
+enum WasmValidationError {
     /// Initial table size outside allowed bounds.
     #[error("initial table size of {actual} exceeds allowed limit of {max}")]
     InitialTableSizeExceeded {
@@ -82,13 +86,17 @@ pub enum PreprocessingError {
     MissingMemorySection,
     /// The module is missing.
     MissingModule,
-    /// Wasm validation did not pass.
-    InvalidWasm(#[from] WasmValidationError),
 }
 
 impl From<elements::Error> for PreprocessingError {
     fn from(error: elements::Error) -> Self {
         PreprocessingError::Deserialize(error.to_string())
+    }
+}
+
+impl From<WasmValidationError> for PreprocessingError {
+    fn from(wasm_validation_error: WasmValidationError) -> Self {
+        Self::Deserialize(wasm_validation_error.to_string())
     }
 }
 
@@ -100,7 +108,6 @@ impl Display for PreprocessingError {
             PreprocessingError::StackLimiter => write!(f, "Stack limiter error"),
             PreprocessingError::MissingMemorySection => write!(f, "Memory section should exist"),
             PreprocessingError::MissingModule => write!(f, "Missing module"),
-            PreprocessingError::InvalidWasm(msg) => write!(f, "Invalid wasm: {msg}."),
         }
     }
 }
@@ -222,14 +229,6 @@ fn ensure_parameter_limit(module: &Module, limit: u32) -> Result<(), WasmValidat
     Ok(())
 }
 
-/// List of invalid wasm imports considered non-existing.
-const WASM_INVALID_IMPORTS: &[(&str, &str)] = &[
-    // Gas counter is currently considered an implementation detail.
-    //
-    // If a wasm module tries to import it will be rejected.
-    (DEFAULT_GAS_MODULE_NAME, "gas"),
-];
-
 /// Ensures that Wasm module has valid imports.
 fn ensure_valid_imports(module: &Module) -> Result<(), WasmValidationError> {
     let import_entries = module
@@ -237,14 +236,14 @@ fn ensure_valid_imports(module: &Module) -> Result<(), WasmValidationError> {
         .map(|is| is.entries())
         .unwrap_or(&[]);
 
+    // Gas counter is currently considered an implementation detail.
+    //
+    // If a wasm module tries to import it will be rejected.
+
     for import in import_entries {
-        if WASM_INVALID_IMPORTS
-            .iter()
-            .any(|(module, func_name)| (import.module(), import.field()) == (*module, *func_name))
+        if import.module() == DEFAULT_GAS_MODULE_NAME
+            && import.field() == INTERNAL_GAS_FUNCTION_NAME
         {
-            // Currently we're checking the imports against the list of invalid imports such as
-            // special "gas" function, but this should be extended to also check if the provided
-            // imports are on the list of host functions.
             return Err(WasmValidationError::MissingHostFunction);
         }
     }

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -1,7 +1,10 @@
 //! Preprocessing of Wasm modules.
 use std::fmt::{self, Display, Formatter};
 
-use parity_wasm::elements::{self, Instruction, MemorySection, Module, Section, TableType, Type};
+use parity_wasm::elements::{
+    self, External, FunctionType, Instruction, Internal, MemorySection, Module, Section, TableType,
+    Type,
+};
 use pwasm_utils::{self, stack_height};
 use thiserror::Error;
 
@@ -73,6 +76,18 @@ enum WasmValidationError {
     /// Opcode for a global access refers to a non-existing global
     #[error("opcode for a global access refers to non-existing global index {index}")]
     IncorrectGlobalOperation {
+        /// Provided index.
+        index: u32,
+    },
+    /// Missing function index.
+    #[error("missing function index {index}")]
+    MissingFunctionIndex {
+        /// Provided index.
+        index: u32,
+    },
+    /// Missing function type.
+    #[error("missing type index {index}")]
+    MissingFunctionType {
         /// Provided index.
         index: u32,
     },
@@ -301,31 +316,104 @@ pub fn preprocess(
 }
 
 fn ensure_valid_access(module: &Module) -> Result<(), WasmValidationError> {
-    let code_section = if let Some(type_section) = module.code_section() {
-        type_section
-    } else {
-        return Ok(());
-    };
+    // Copy types from module as is.
+    let types: Vec<FunctionType> = module
+        .type_section()
+        .map(|ts| {
+            ts.types()
+                .iter()
+                .map(|&Type::Function(ref ty)| ty)
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default();
 
-    let global_len = module
-        .global_section()
-        .map(|global_section| global_section.entries().len())
-        .unwrap_or(0);
+    // Function space that contains indexes of imported functions from import section and indexes
+    // from function section.
+    //
+    // It is an indirection from the i-th element of the index space into a type section as created
+    // in the `types` variable above.
+    let mut func_type_indices = Vec::new();
 
-    for instr in code_section
-        .bodies()
-        .iter()
-        .flat_map(|body| body.code().elements())
-    {
-        match instr {
-            Instruction::GetGlobal(idx) | Instruction::SetGlobal(idx)
-                if *idx as usize >= global_len =>
-            {
-                return Err(WasmValidationError::IncorrectGlobalOperation { index: *idx })
+    if let Some(import_section) = module.import_section() {
+        for import_entry in import_section.entries() {
+            if let External::Function(idx) = import_entry.external() {
+                func_type_indices.push((*idx, false));
             }
-            _ => {}
         }
     }
+
+    if let Some(function_section) = module.function_section() {
+        for function_entry in function_section.entries() {
+            let idx = function_entry.type_ref();
+            func_type_indices.push((idx, false));
+        }
+    }
+
+    if let Some(idx) = module.start_section() {
+        ensure_function_exists(&idx, &mut func_type_indices, &types)?;
+    }
+
+    if let Some(export_section) = module.export_section() {
+        for export_entry in export_section.entries() {
+            if let Internal::Function(idx) = export_entry.internal() {
+                ensure_function_exists(idx, &mut func_type_indices, &types)?;
+            }
+        }
+    }
+
+    if let Some(code_section) = module.code_section() {
+        let global_len = module
+            .global_section()
+            .map(|global_section| global_section.entries().len())
+            .unwrap_or(0);
+
+        for instr in code_section
+            .bodies()
+            .iter()
+            .flat_map(|body| body.code().elements())
+        {
+            match instr {
+                Instruction::Call(idx) => {
+                    ensure_function_exists(idx, &mut func_type_indices, &types)?
+                }
+                Instruction::GetGlobal(idx) | Instruction::SetGlobal(idx)
+                    if *idx as usize >= global_len =>
+                {
+                    return Err(WasmValidationError::IncorrectGlobalOperation { index: *idx })
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if let Some(element_section) = module.elements_section() {
+        for element_segment in element_section.entries() {
+            for idx in element_segment.members() {
+                ensure_function_exists(idx, &mut func_type_indices, &types)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Ensures a function exists in a types table.
+fn ensure_function_exists(
+    idx: &u32,
+    func_type_indices: &mut [(u32, bool)],
+    types: &[FunctionType],
+) -> Result<(), WasmValidationError> {
+    let (ty_idx, is_validated) = func_type_indices
+        .get_mut(*idx as usize)
+        .ok_or(WasmValidationError::MissingFunctionIndex { index: *idx })?;
+    if *is_validated {
+        return Ok(());
+    }
+    let _ty = types
+        .get(*ty_idx as usize)
+        .ok_or(WasmValidationError::MissingFunctionType { index: *ty_idx })?;
+    *is_validated = true;
     Ok(())
 }
 
@@ -337,7 +425,10 @@ pub fn deserialize(module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
 #[cfg(test)]
 mod tests {
     use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
-    use parity_wasm::{builder, elements::Instructions};
+    use parity_wasm::{
+        builder,
+        elements::{CodeSection, Instructions},
+    };
 
     use super::*;
 
@@ -449,16 +540,37 @@ mod tests {
         let error = preprocess(WasmConfig::default(), &module_bytes)
             .expect_err("should fail with an error");
         assert!(
-            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            matches!(&error, PreprocessingError::Deserialize(msg)
+            if msg == &format!("missing function index {index}", index=u32::MAX)),
             "{:?}",
             error,
         );
     }
 
     #[test]
-    fn should_not_overflow_in_start_section() {
+    fn should_not_overflow_in_start_section_without_code_section() {
         let module = builder::module()
             .with_section(Section::Start(u32::MAX))
+            .memory()
+            .build()
+            .build();
+        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(msg)
+            if msg == &format!("missing function index {index}", index=u32::MAX)),
+            "{:?}",
+            error,
+        );
+    }
+
+    #[test]
+    fn should_not_overflow_in_start_section_with_code() {
+        let module = builder::module()
+            .with_section(Section::Start(u32::MAX))
+            .with_section(Section::Code(CodeSection::with_bodies(Vec::new())))
             .memory()
             .build()
             .build();
@@ -466,7 +578,8 @@ mod tests {
         let error = preprocess(WasmConfig::default(), &module_bytes)
             .expect_err("should fail with an error");
         assert!(
-            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            matches!(&error, PreprocessingError::Deserialize(msg)
+            if msg == &format!("missing function index {index}", index=u32::MAX)),
             "{:?}",
             error,
         );

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -1,7 +1,7 @@
 //! Preprocessing of Wasm modules.
 use std::fmt::{self, Display, Formatter};
 
-use parity_wasm::elements::{self, MemorySection, Module, Section, TableType};
+use parity_wasm::elements::{self, Instruction, MemorySection, Module, Section, TableType};
 use pwasm_utils::{self, stack_height};
 use thiserror::Error;
 
@@ -10,6 +10,8 @@ use super::wasm_config::WasmConfig;
 const DEFAULT_GAS_MODULE_NAME: &str = "env";
 /// We only allow maximum of 4k function pointers in a table section.
 pub const DEFAULT_MAX_TABLE_SIZE: u32 = 4096;
+/// Maximum number of elements that can appear as immediate value to the br_table instruction.
+pub const DEFAULT_BR_TABLE_MAX_SIZE: u32 = 256;
 
 /// An error emitted by the Wasm preprocessor.
 #[derive(Debug, Clone, Error)]
@@ -33,6 +35,14 @@ pub enum WasmValidationError {
     /// Number of the tables in a Wasm must be at most one.
     #[error("the number of tables must be at most one")]
     MoreThanOneTable,
+    /// Length of a br_table exceeded the maximum allowed size.
+    #[error("maximum br_table size exceeds allowed bounds (expected {max} but found {actual})")]
+    BrTableSizeExceeded {
+        /// Maximum allowed br_table length.
+        max: u32,
+        /// Actual size of the largest br_table in the code.
+        actual: usize,
+    },
 }
 
 /// An error emitted by the Wasm preprocessor.
@@ -128,6 +138,30 @@ fn ensure_table_size_limit(mut module: Module) -> Result<Module, WasmValidationE
     Ok(module)
 }
 
+/// Ensure that any `br_table` instruction adheres to its immediate value limit.
+fn ensure_br_table_size_limit(module: &Module) -> Result<(), WasmValidationError> {
+    let code_section = if let Some(type_section) = module.code_section() {
+        type_section
+    } else {
+        return Ok(());
+    };
+    for instr in code_section
+        .bodies()
+        .iter()
+        .flat_map(|body| body.code().elements())
+    {
+        if let Instruction::BrTable(br_table_data) = instr {
+            if br_table_data.table.len() > DEFAULT_BR_TABLE_MAX_SIZE as usize {
+                return Err(WasmValidationError::BrTableSizeExceeded {
+                    max: DEFAULT_BR_TABLE_MAX_SIZE,
+                    actual: br_table_data.table.len(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Preprocesses Wasm bytes and returns a module.
 ///
 /// This process consists of a few steps:
@@ -152,6 +186,7 @@ pub fn preprocess(
     }
 
     let module = ensure_table_size_limit(module)?;
+    ensure_br_table_size_limit(&module)?;
 
     let module = pwasm_utils::externalize_mem(module, None, wasm_config.max_memory);
     let module = pwasm_utils::inject_gas_counter(

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -336,6 +336,9 @@ pub fn deserialize(module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
 
 #[cfg(test)]
 mod tests {
+    use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
+    use parity_wasm::{builder, elements::Instructions};
+
     use super::*;
 
     #[test]
@@ -354,5 +357,118 @@ mod tests {
             PreprocessingError::MissingMemorySection => (),
             error => panic!("expected MissingMemorySection, got {:?}", error),
         }
+    }
+
+    #[test]
+    fn should_not_overflow_in_export_section() {
+        let module = builder::module()
+            .function()
+            .signature()
+            .build()
+            .body()
+            .with_instructions(Instructions::new(vec![Instruction::Nop, Instruction::End]))
+            .build()
+            .build()
+            .export()
+            .field(DEFAULT_ENTRY_POINT_NAME)
+            .internal()
+            .func(u32::MAX)
+            .build()
+            // Memory section is mandatory
+            .memory()
+            .build()
+            .build();
+        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            "{:?}",
+            error,
+        );
+    }
+
+    #[test]
+    fn should_not_overflow_in_element_section() {
+        const CALL_FN_IDX: u32 = 0;
+
+        let module = builder::module()
+            .function()
+            .signature()
+            .build()
+            .body()
+            .with_instructions(Instructions::new(vec![Instruction::Nop, Instruction::End]))
+            .build()
+            .build()
+            // Export above function
+            .export()
+            .field(DEFAULT_ENTRY_POINT_NAME)
+            .internal()
+            .func(CALL_FN_IDX)
+            .build()
+            .table()
+            .with_element(u32::MAX, vec![u32::MAX])
+            .build()
+            // Memory section is mandatory
+            .memory()
+            .build()
+            .build();
+        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            "{:?}",
+            error,
+        );
+    }
+
+    #[test]
+    fn should_not_overflow_in_call_opcode() {
+        let module = builder::module()
+            .function()
+            .signature()
+            .build()
+            .body()
+            .with_instructions(Instructions::new(vec![
+                Instruction::Call(u32::MAX),
+                Instruction::End,
+            ]))
+            .build()
+            .build()
+            // Export above function
+            .export()
+            .field(DEFAULT_ENTRY_POINT_NAME)
+            .build()
+            // .with_sections(vec![Section::Start(u32::MAX)])
+            // Memory section is mandatory
+            .memory()
+            .build()
+            .build();
+        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            "{:?}",
+            error,
+        );
+    }
+
+    #[test]
+    fn should_not_overflow_in_start_section() {
+        let module = builder::module()
+            .with_section(Section::Start(u32::MAX))
+            .memory()
+            .build()
+            .build();
+        let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+        let error = preprocess(WasmConfig::default(), &module_bytes)
+            .expect_err("should fail with an error");
+        assert!(
+            matches!(&error, PreprocessingError::Deserialize(_msg)),
+            "{:?}",
+            error,
+        );
     }
 }

--- a/execution_engine/src/shared/wasm_prep.rs
+++ b/execution_engine/src/shared/wasm_prep.rs
@@ -124,7 +124,7 @@ fn memory_section(module: &Module) -> Option<&MemorySection> {
 /// normalized.
 ///
 /// If a maximum value is not specified it will be defaulted to 4k to prevent OOM.
-fn ensure_table_size_limit(mut module: Module) -> Result<Module, WasmValidationError> {
+fn ensure_table_size_limit(mut module: Module, limit: u32) -> Result<Module, WasmValidationError> {
     if let Some(sect) = module.table_section_mut() {
         // Table section is optional and there can be at most one.
         if sect.entries().len() > 1 {
@@ -133,26 +133,25 @@ fn ensure_table_size_limit(mut module: Module) -> Result<Module, WasmValidationE
 
         if let Some(table_entry) = sect.entries_mut().iter_mut().next() {
             let initial = table_entry.limits().initial();
-            if initial > DEFAULT_MAX_TABLE_SIZE {
+            if initial > limit {
                 return Err(WasmValidationError::InitialTableSizeExceeded {
-                    max: DEFAULT_MAX_TABLE_SIZE,
+                    max: limit,
                     actual: initial,
                 });
             }
 
             match table_entry.limits().maximum() {
-                Some(max) if max > DEFAULT_MAX_TABLE_SIZE => {
-                    return Err(WasmValidationError::MaxTableSizeExceeded {
-                        max: DEFAULT_MAX_TABLE_SIZE,
-                        actual: max,
-                    })
-                }
-                Some(_) => {
-                    // maximum within the limit
+                Some(max) => {
+                    if max > limit {
+                        return Err(WasmValidationError::MaxTableSizeExceeded {
+                            max: limit,
+                            actual: max,
+                        });
+                    }
                 }
                 None => {
                     // rewrite wasm and provide a maximum limit for a table section
-                    *table_entry = TableType::new(initial, Some(DEFAULT_MAX_TABLE_SIZE))
+                    *table_entry = TableType::new(initial, Some(limit))
                 }
             }
         }
@@ -167,21 +166,18 @@ fn ensure_table_size_limit(mut module: Module) -> Result<Module, WasmValidationE
 /// the linear memory limit `memory_pages` applies to them.
 ///
 /// There is potential to
-fn ensure_global_variable_limit(module: &Module) -> Result<(), WasmValidationError> {
+fn ensure_global_variable_limit(module: &Module, limit: u32) -> Result<(), WasmValidationError> {
     if let Some(global_section) = module.global_section() {
         let actual = global_section.entries().len();
-        if actual > DEFAULT_MAX_GLOBALS as usize {
-            return Err(WasmValidationError::TooManyGlobals {
-                max: DEFAULT_MAX_GLOBALS,
-                actual,
-            });
+        if actual > limit as usize {
+            return Err(WasmValidationError::TooManyGlobals { max: limit, actual });
         }
     }
     Ok(())
 }
 
 /// Ensure that any `br_table` instruction adheres to its immediate value limit.
-fn ensure_br_table_size_limit(module: &Module) -> Result<(), WasmValidationError> {
+fn ensure_br_table_size_limit(module: &Module, limit: u32) -> Result<(), WasmValidationError> {
     let code_section = if let Some(type_section) = module.code_section() {
         type_section
     } else {
@@ -193,9 +189,9 @@ fn ensure_br_table_size_limit(module: &Module) -> Result<(), WasmValidationError
         .flat_map(|body| body.code().elements())
     {
         if let Instruction::BrTable(br_table_data) = instr {
-            if br_table_data.table.len() > DEFAULT_BR_TABLE_MAX_SIZE as usize {
+            if br_table_data.table.len() > limit as usize {
                 return Err(WasmValidationError::BrTableSizeExceeded {
-                    max: DEFAULT_BR_TABLE_MAX_SIZE,
+                    max: limit,
                     actual: br_table_data.table.len(),
                 });
             }
@@ -212,7 +208,7 @@ fn ensure_br_table_size_limit(module: &Module) -> Result<(), WasmValidationError
 /// of parameters of this function. Because the stack height instrumentation itself is
 /// is not weight metered its costs must be static (via this limit) and included in
 /// the costs of the instructions that cause them (call, call_indirect).
-fn ensure_parameter_limit(module: &Module) -> Result<(), WasmValidationError> {
+fn ensure_parameter_limit(module: &Module, limit: u32) -> Result<(), WasmValidationError> {
     let type_section = if let Some(type_section) = module.type_section() {
         type_section
     } else {
@@ -221,11 +217,8 @@ fn ensure_parameter_limit(module: &Module) -> Result<(), WasmValidationError> {
 
     for Type::Function(func) in type_section.types() {
         let actual = func.params().len();
-        if actual > DEFAULT_MAX_PARAMETER_COUNT as usize {
-            return Err(WasmValidationError::TooManyParameters {
-                max: DEFAULT_MAX_PARAMETER_COUNT,
-                actual,
-            });
+        if actual > limit as usize {
+            return Err(WasmValidationError::TooManyParameters { max: limit, actual });
         }
     }
 
@@ -285,10 +278,10 @@ pub fn preprocess(
         return Err(PreprocessingError::MissingMemorySection);
     }
 
-    let module = ensure_table_size_limit(module)?;
-    ensure_br_table_size_limit(&module)?;
-    ensure_global_variable_limit(&module)?;
-    ensure_parameter_limit(&module)?;
+    let module = ensure_table_size_limit(module, DEFAULT_MAX_TABLE_SIZE)?;
+    ensure_br_table_size_limit(&module, DEFAULT_BR_TABLE_MAX_SIZE)?;
+    ensure_global_variable_limit(&module, DEFAULT_MAX_GLOBALS)?;
+    ensure_parameter_limit(&module, DEFAULT_MAX_PARAMETER_COUNT)?;
     ensure_valid_imports(&module)?;
 
     let module = pwasm_utils::externalize_mem(module, None, wasm_config.max_memory);

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license = "Apache-2.0"
 
 [dependencies]
-casper-execution-engine = { version = "2.0.0", path = "../../execution_engine", features = ["test-support"] }
+casper-execution-engine = { version = "2.0.1", path = "../../execution_engine", features = ["test-support"] }
 casper-hashing = { version = "1.4.3", path = "../../hashing" }
 casper-types = { version = "1.5.0", path = "../../types" }
 humantime = "2"

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -27,6 +27,7 @@ tempfile = "3"
 wabt = "0.10.0"
 wasmi = "0.8.0"
 regex = "1.5.4"
+wat = "1.0.47"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/execution_engine_testing/tests/src/test/regression/gov_74.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_74.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -17,12 +15,21 @@ use casper_execution_engine::{
         },
         execution::Error as ExecError,
     },
-    shared::wasm_config::{WasmConfig, DEFAULT_WASM_MAX_MEMORY},
+    shared::{
+        wasm_config::{WasmConfig, DEFAULT_WASM_MAX_MEMORY},
+        wasm_prep::DEFAULT_MAX_PARAMETER_COUNT,
+    },
 };
 use casper_types::{EraId, ProtocolVersion, RuntimeArgs};
 
-const I32_WASM_SIZE_BYTES: usize = 8;
-const ARITY_INTERPRETER_LIMIT: usize = wasmi::DEFAULT_CALL_STACK_LIMIT / I32_WASM_SIZE_BYTES;
+use crate::wasm_utils;
+
+// Previously this value was derived from `wasmi::DEFAULT_CALL_STACK_LIMIT` as we haven't a check
+// for argument count declared in wasm functions. We have very restrictive stack height which also
+// means the maximum allowed function count still fails at runtime inside the stack limiter.
+//
+// Max parameter count - 1 will exercise the height limiter while passing the preprocessing stage.
+const ARITY_INTERPRETER_LIMIT: usize = DEFAULT_MAX_PARAMETER_COUNT as usize - 1;
 const DEFAULT_ACTIVATION_POINT: EraId = EraId::new(1);
 const I32_WAT_TYPE: &str = "i64";
 const NEW_WASM_STACK_HEIGHT: u32 = 16;
@@ -36,32 +43,6 @@ static NEW_PROTOCOL_VERSION: Lazy<ProtocolVersion> = Lazy::new(|| {
     )
 });
 
-fn make_n_arg_call_bytes(arity: usize, arg_type: &str) -> Vec<u8> {
-    let mut call_args = String::new();
-    for i in 0..arity {
-        write!(call_args, "({}.const {}) ", arg_type, i).unwrap();
-    }
-
-    let mut func_params = String::new();
-    for i in 0..arity {
-        write!(func_params, "(param $arg{} {}) ", i, arg_type).unwrap();
-    }
-
-    // This wasm module contains a function with a specified amount of arguments in it.
-    let wat = format!(
-        r#"(module
-        (func $call (call $func {call_args}) (return))
-        (func $func {func_params} (return))
-        (export "func" (func $func))
-        (export "call" (func $call))
-        (memory $memory 1)
-      )"#,
-        call_args = call_args,
-        func_params = func_params
-    );
-    wabt::wat2wasm(wat).expect("should parse wat")
-}
-
 fn initialize_builder() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
     builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
@@ -74,7 +55,9 @@ fn should_verify_interpreter_stack_limit() {
     let mut builder = initialize_builder();
 
     // This runs out of the interpreter stack limit
-    let module_bytes = make_n_arg_call_bytes(ARITY_INTERPRETER_LIMIT, I32_WAT_TYPE);
+    let module_bytes = wasm_utils::make_n_arg_call_bytes(ARITY_INTERPRETER_LIMIT, I32_WAT_TYPE)
+        .expect("should make wasm bytes");
+
     let exec = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,
@@ -105,7 +88,9 @@ fn should_observe_stack_height_limit() {
 
     // This runs out of the interpreter stack limit
     let exec_request_1 = {
-        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE);
+        let module_bytes =
+            wasm_utils::make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE)
+                .expect("should make wasm bytes");
 
         ExecuteRequestBuilder::module_bytes(
             *DEFAULT_ACCOUNT_ADDR,
@@ -149,7 +134,9 @@ fn should_observe_stack_height_limit() {
     // An amount of args equal to the new limit fails because there's overhead of `fn call` that
     // adds 1 to the height.
     let exec_request_2 = {
-        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE);
+        let module_bytes =
+            wasm_utils::make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize, I32_WAT_TYPE)
+                .expect("should make wasm bytes");
 
         ExecuteRequestBuilder::module_bytes(
             *DEFAULT_ACCOUNT_ADDR,
@@ -171,7 +158,9 @@ fn should_observe_stack_height_limit() {
 
     // But new limit minus one runs fine
     let exec_request_3 = {
-        let module_bytes = make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize - 1, I32_WAT_TYPE);
+        let module_bytes =
+            wasm_utils::make_n_arg_call_bytes(NEW_WASM_STACK_HEIGHT as usize - 1, I32_WAT_TYPE)
+                .expect("should make wasm bytes");
 
         ExecuteRequestBuilder::module_bytes(
             *DEFAULT_ACCOUNT_ADDR,

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -57,5 +57,6 @@ mod regression_20220222;
 mod regression_20220223;
 mod regression_20220224;
 mod regression_20220303;
+mod regression_20220727;
 pub(crate) mod test_utils;
 mod transforms_must_be_ordered;

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -1,0 +1,261 @@
+use std::fmt::Write;
+
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    DEFAULT_RUN_GENESIS_REQUEST,
+};
+use casper_execution_engine::{
+    core::{engine_state, execution},
+    shared::wasm_prep::PreprocessingError,
+};
+use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
+use parity_wasm::{
+    builder,
+    elements::{Instruction, Instructions},
+};
+
+fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
+    let mut bounds = initial.to_string();
+    if let Some(max) = maximum {
+        bounds += " ";
+        bounds += &max.to_string();
+    }
+
+    let wat = format!(
+        r#"(module
+            (table (;0;) {} funcref)
+            (memory (;0;) 0)
+            (export "call" (func $call))
+            (func $call))
+            "#,
+        bounds
+    );
+    wabt::wat2wasm(wat).expect("should parse wat")
+}
+
+const OOM_INIT: (u32, Option<u32>) = (2805655325, None);
+const FAILURE_ONE_ABOVE_LIMIT: (u32, Option<u32>) = (65537, None);
+const FAILURE_MAX_ABOVE_LIMIT: (u32, Option<u32>) = (65536, Some(u32::MAX));
+const FAILURE_INIT_ABOVE_LIMIT: (u32, Option<u32>) = (u32::MAX, Some(u32::MAX));
+const ALLOWED_NO_MAX: (u32, Option<u32>) = (65536, None);
+const ALLOWED_LIMITS: (u32, Option<u32>) = (65536, Some(65536));
+
+#[ignore]
+#[test]
+fn should_not_oom() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    let test_cases = vec![
+        OOM_INIT,
+        FAILURE_ONE_ABOVE_LIMIT,
+        FAILURE_MAX_ABOVE_LIMIT,
+        FAILURE_INIT_ABOVE_LIMIT,
+    ];
+
+    for (initial, maximum) in test_cases {
+        let module_bytes = make_oom_payload(initial, maximum);
+        let exec_request = ExecuteRequestBuilder::module_bytes(
+            *DEFAULT_ACCOUNT_ADDR,
+            module_bytes,
+            RuntimeArgs::default(),
+        )
+        .build();
+
+        builder.exec(exec_request).expect_failure().commit();
+
+        let error = builder.get_error().unwrap();
+
+        assert!(matches!(
+            error,
+            engine_state::Error::WasmPreprocessing(PreprocessingError::InvalidWasm(ref _msg))
+        ))
+    }
+}
+
+#[ignore]
+#[test]
+fn should_pass_table_validation() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    let passing_test_cases = vec![ALLOWED_NO_MAX, ALLOWED_LIMITS];
+
+    for (initial, maximum) in passing_test_cases {
+        let module_bytes = make_oom_payload(initial, maximum);
+        let exec_request = ExecuteRequestBuilder::module_bytes(
+            *DEFAULT_ACCOUNT_ADDR,
+            module_bytes,
+            RuntimeArgs::default(),
+        )
+        .build();
+
+        builder.exec(exec_request).expect_success().commit();
+    }
+}
+
+#[ignore]
+#[test]
+fn should_pass_elem_section() {
+    // more functions than elements - wasmi doesn't allocate
+    let elem_does_not_fit_err = test_element_section(0, None, 65536);
+    assert!(
+        matches!(
+            elem_does_not_fit_err,
+            Some(engine_state::Error::Exec(execution::Error::Interpreter(ref msg)))
+            if msg == "elements segment does not fit"
+        ),
+        "{:?}",
+        elem_does_not_fit_err
+    );
+
+    // wasmi assumes table size and function pointers are equal
+    assert!(matches!(
+        test_element_section(65536, Some(65536), 65536),
+        None
+    ));
+}
+
+fn test_element_section(
+    table_init: u32,
+    table_max: Option<u32>,
+    function_count: u32,
+) -> Option<engine_state::Error> {
+    // Ensures proper initialization of table elements for different number of function pointers
+    //
+    // This should ensure there's no hidden lazy allocation and initialization that might still
+    // overallocate memory, burn cpu cycles allocating etc.
+
+    // (module
+    //     (table 0 1 anyfunc)
+    //     (memory $0 1)
+    //     (export "memory" (memory $0))
+    //     (export "foo1" (func $foo1))
+    //     (export "foo2" (func $foo2))
+    //     (export "foo3" (func $foo3))
+    //     (export "main" (func $main))
+    //     (func $foo1 (; 0 ;)
+    //     )
+    //     (func $foo2 (; 1 ;)
+    //     )
+    //     (func $foo3 (; 2 ;)
+    //     )
+    //     (func $main (; 3 ;) (result i32)
+    //      (i32.const 0)
+    //     )
+    //     (elem (i32.const 0) $foo1 $foo2 $foo3)
+    // )
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    let mut wat = String::new();
+
+    if let Some(max) = table_max {
+        writeln!(
+            wat,
+            r#"(module
+            (table {table_init} {max} anyfunc)"#
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            wat,
+            r#"(module
+            (table {table_init} anyfunc)"#
+        )
+        .unwrap();
+    }
+
+    wat += "(memory $0 1)\n";
+    wat += r#"(export "memory" (memory $0))"#;
+    wat += "\n";
+    wat += r#"(export "call" (func $call))"#;
+    wat += "\n";
+    for i in 0..function_count {
+        writeln!(wat, r#"(export "foo{i}" (func $foo{i}))"#).unwrap();
+    }
+    for i in 0..function_count {
+        writeln!(wat, "(func $foo{i} (; 0 ;))").unwrap();
+    }
+    wat += "(func $call)\n";
+    wat += "\n";
+    wat += "(elem (i32.const 0) ";
+    for i in 0..function_count {
+        write!(wat, "$foo{i} ").unwrap();
+    }
+    wat += ")\n";
+    wat += ")";
+
+    let module_bytes = wabt::wat2wasm(wat).unwrap();
+    let exec_request = ExecuteRequestBuilder::module_bytes(
+        *DEFAULT_ACCOUNT_ADDR,
+        module_bytes,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(exec_request).commit();
+
+    builder.get_error()
+}
+
+#[ignore]
+#[test]
+fn should_not_allow_more_than_one_table() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+
+    // wabt::wat2wasm doesn't allow multiple tables so we'll go with a builder
+
+    let module = builder::module()
+        // table 1
+        .table()
+        .with_min(0)
+        .build()
+        // table 2
+        .table()
+        .with_min(1)
+        .build()
+        .function()
+        // A signature with 0 params and no return type
+        .signature()
+        .build()
+        .body()
+        // Generated instructions for our entrypoint
+        .with_instructions(Instructions::new(vec![Instruction::Nop, Instruction::End]))
+        .build()
+        .build()
+        // Export above function
+        .export()
+        .field(DEFAULT_ENTRY_POINT_NAME)
+        .build()
+        // Memory section is mandatory
+        .memory()
+        .build()
+        .build();
+    let module_bytes = parity_wasm::serialize(module).expect("should serialize");
+
+    let exec_request = ExecuteRequestBuilder::module_bytes(
+        *DEFAULT_ACCOUNT_ADDR,
+        module_bytes,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(exec_request).expect_failure().commit();
+
+    let error = builder.get_error().unwrap();
+
+    // Thankfully we don't fail at preprocess stage and wasmi actually rejects instances with more
+    // than 1 table.
+    assert!(
+        matches!(
+            error,
+            engine_state::Error::Exec(execution::Error::Interpreter(ref msg))
+            if msg == "too many tables in index space: 2"
+        ),
+        "{:?}",
+        error
+    );
+}

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -6,7 +6,7 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::{engine_state, execution},
-    shared::wasm_prep::PreprocessingError,
+    shared::wasm_prep::{PreprocessingError, DEFAULT_MAX_TABLE_SIZE},
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
 use parity_wasm::{
@@ -34,11 +34,11 @@ fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
 }
 
 const OOM_INIT: (u32, Option<u32>) = (2805655325, None);
-const FAILURE_ONE_ABOVE_LIMIT: (u32, Option<u32>) = (65537, None);
-const FAILURE_MAX_ABOVE_LIMIT: (u32, Option<u32>) = (65536, Some(u32::MAX));
+const FAILURE_ONE_ABOVE_LIMIT: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE + 1, None);
+const FAILURE_MAX_ABOVE_LIMIT: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE, Some(u32::MAX));
 const FAILURE_INIT_ABOVE_LIMIT: (u32, Option<u32>) = (u32::MAX, Some(u32::MAX));
-const ALLOWED_NO_MAX: (u32, Option<u32>) = (65536, None);
-const ALLOWED_LIMITS: (u32, Option<u32>) = (65536, Some(65536));
+const ALLOWED_NO_MAX: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE, None);
+const ALLOWED_LIMITS: (u32, Option<u32>) = (DEFAULT_MAX_TABLE_SIZE, Some(DEFAULT_MAX_TABLE_SIZE));
 
 #[ignore]
 #[test]
@@ -98,7 +98,7 @@ fn should_pass_table_validation() {
 #[test]
 fn should_pass_elem_section() {
     // more functions than elements - wasmi doesn't allocate
-    let elem_does_not_fit_err = test_element_section(0, None, 65536);
+    let elem_does_not_fit_err = test_element_section(0, None, DEFAULT_MAX_TABLE_SIZE);
     assert!(
         matches!(
             elem_does_not_fit_err,
@@ -111,7 +111,11 @@ fn should_pass_elem_section() {
 
     // wasmi assumes table size and function pointers are equal
     assert!(matches!(
-        test_element_section(65536, Some(65536), 65536),
+        test_element_section(
+            DEFAULT_MAX_TABLE_SIZE,
+            Some(DEFAULT_MAX_TABLE_SIZE),
+            DEFAULT_MAX_TABLE_SIZE
+        ),
         None
     ));
 }

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -11,7 +11,7 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::{engine_state, execution},
-    shared::wasm_prep::{PreprocessingError, DEFAULT_MAX_TABLE_SIZE},
+    shared::wasm_prep::{PreprocessingError, WasmValidationError, DEFAULT_MAX_TABLE_SIZE},
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
 
@@ -252,13 +252,12 @@ fn should_not_allow_more_than_one_table() {
 
     let error = builder.get_error().unwrap();
 
-    // Thankfully we don't fail at preprocess stage and wasmi actually rejects instances with more
-    // than 1 table.
     assert!(
         matches!(
             error,
-            engine_state::Error::Exec(execution::Error::Interpreter(ref msg))
-            if msg == "too many tables in index space: 2"
+            engine_state::Error::WasmPreprocessing(PreprocessingError::InvalidWasm(
+                WasmValidationError::MoreThanOneTable
+            ))
         ),
         "{:?}",
         error

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -512,7 +512,7 @@ fn should_verify_max_param_count() {
 
     let error = builder.get_error().expect("should have error");
 
-    // Here we pass the preprocess stage, but we wail at stack height limiter as we do have very
+    // Here we pass the preprocess stage, but we fail at stack height limiter as we do have very
     // restrictive default stack height.
     assert!(
         matches!(&error, Error::Exec(execution::Error::Interpreter(s)) if s.contains("Unreachable")),

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -1,5 +1,10 @@
 use std::fmt::Write;
 
+use parity_wasm::{
+    builder,
+    elements::{Instruction, Instructions},
+};
+
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_RUN_GENESIS_REQUEST,
@@ -9,10 +14,6 @@ use casper_execution_engine::{
     shared::wasm_prep::{PreprocessingError, DEFAULT_MAX_TABLE_SIZE},
 };
 use casper_types::{contracts::DEFAULT_ENTRY_POINT_NAME, RuntimeArgs};
-use parity_wasm::{
-    builder,
-    elements::{Instruction, Instructions},
-};
 
 fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
     let mut bounds = initial.to_string();

--- a/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20220727.rs
@@ -7,7 +7,7 @@ use parity_wasm::{
 
 use casper_engine_test_support::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
-    DEFAULT_RUN_GENESIS_REQUEST,
+    PRODUCTION_RUN_GENESIS_REQUEST,
 };
 use casper_execution_engine::{
     core::{
@@ -58,7 +58,7 @@ fn make_oom_payload(initial: u32, maximum: Option<u32>) -> Vec<u8> {
 #[test]
 fn should_not_oom() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let test_cases = vec![
         OOM_INIT,
@@ -91,7 +91,7 @@ fn should_not_oom() {
 #[test]
 fn should_pass_table_validation() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let passing_test_cases = vec![ALLOWED_NO_MAX, ALLOWED_LIMITS];
 
@@ -165,7 +165,7 @@ fn test_element_section(
     // )
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let mut wat = String::new();
 
@@ -222,7 +222,7 @@ fn test_element_section(
 #[test]
 fn should_not_allow_more_than_one_table() {
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     // wabt::wat2wasm doesn't allow multiple tables so we'll go with a builder
 
@@ -354,7 +354,7 @@ fn should_allow_large_br_table() {
         .expect("should create module bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -373,7 +373,7 @@ fn should_not_allow_large_br_table() {
         make_arbitrary_br_table(FAILING_BR_TABLE_SIZE).expect("should create module bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -445,7 +445,7 @@ fn should_allow_multiple_globals() {
         make_arbitrary_global(DEFAULT_MAX_GLOBALS as usize).expect("should make arbitrary global");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -464,7 +464,7 @@ fn should_not_allow_too_many_globals() {
         make_arbitrary_global(FAILING_GLOBALS_SIZE).expect("should make arbitrary global");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -496,7 +496,7 @@ fn should_verify_max_param_count() {
             .expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -521,7 +521,7 @@ fn should_verify_max_param_count() {
         wasm_utils::make_n_arg_call_bytes(100, "i32").expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -540,7 +540,7 @@ fn should_not_allow_too_many_params() {
         .expect("should create wasm bytes");
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -576,7 +576,7 @@ fn should_not_allow_to_import_gas_function() {
     .unwrap();
 
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
 
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
@@ -710,7 +710,7 @@ fn should_not_set_non_existing_global_above_declared_range() {
 fn test_non_existing_global(module_wat: &str, index: u32) {
     let module_bytes = wat::parse_str(module_wat).unwrap();
     let mut builder = InMemoryWasmTestBuilder::default();
-    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&*PRODUCTION_RUN_GENESIS_REQUEST);
     let exec_request = ExecuteRequestBuilder::module_bytes(
         *DEFAULT_ACCOUNT_ADDR,
         module_bytes,

--- a/execution_engine_testing/tests/src/wasm_utils.rs
+++ b/execution_engine_testing/tests/src/wasm_utils.rs
@@ -1,4 +1,6 @@
 //! Wasm helpers.
+use std::fmt::Write;
+
 use parity_wasm::builder;
 
 use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
@@ -22,4 +24,33 @@ pub fn do_nothing_bytes() -> Vec<u8> {
         .build()
         .build();
     parity_wasm::serialize(module).expect("should serialize")
+}
+
+/// Creates minimal session code that contains a function with arbitrary number of parameters.
+pub fn make_n_arg_call_bytes(
+    arity: usize,
+    arg_type: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut call_args = String::new();
+    for i in 0..arity {
+        write!(call_args, "({}.const {}) ", arg_type, i)?;
+    }
+
+    let mut func_params = String::new();
+    for i in 0..arity {
+        write!(func_params, "(param $arg{} {}) ", i, arg_type)?;
+    }
+
+    // This wasm module contains a function with a specified amount of arguments in it.
+    let wat = format!(
+        r#"(module
+        (func $call (call $func {call_args}) (return))
+        (func $func {func_params} (return))
+        (export "func" (func $func))
+        (export "call" (func $call))
+        (memory $memory 1)
+      )"#
+    );
+    let module_bytes = wabt::wat2wasm(wat)?;
+    Ok(module_bytes)
 }

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -85,6 +85,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.4.7
+
+### Changed
+* Update `casper-execution-engine` and three `openssl` crates to latest versions.
+
+
+
 ## 1.4.6
 
 ### Changed

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -85,6 +85,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## 1.4.8
+
+### Changed
+* Update `casper-execution-engine`.
+
+
+
 ## 1.4.7
 
 ### Changed

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `enable_server`, `address`, `qps_limit` and `max_body_bytes` to new `speculative_exec_server` section to `config.toml` to configure speculative execution JSON-RPC server (disabled by default).
 * Add `testing` feature to casper-node crate to support test-only functionality (random constructors) on blocks and deploys.
 * The network handshake now contains the hash of the chainspec used and will be successful only if they match.
+* Add an `identity` option to load existing network identity certificates signed by a CA.
 
 ### Changed
 * Detection of a crash no longer triggers DB integrity checks to run on node start; the checks can be triggered manually instead.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.6" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.7" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -20,7 +20,7 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
-casper-execution-engine = { version = "2.0.0", path = "../execution_engine" }
+casper-execution-engine = { version = "2.0.1", path = "../execution_engine" }
 casper-hashing = { version = "1.4.3", path = "../hashing" }
 casper-json-rpc = { version = "0.1.0", path = "../json_rpc" }
 casper-node-macros = { version = "1.4.3", path = "../node_macros" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.4.7" # when updating, also update 'html_root_url' in lib.rs
+version = "1.4.8" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"

--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -614,7 +614,7 @@ fn put_block_to_storage(
         effect_builder
             .into_inner()
             .schedule(
-                storage::Event::StorageRequest(StorageRequest::PutBlock { block, responder }),
+                                                        storage::Event::StorageRequest(Box::new(StorageRequest::PutBlock { block, responder })),
                 QueueKind::Regular,
             )
             .ignore()
@@ -629,7 +629,7 @@ fn put_deploy_to_storage(
         effect_builder
             .into_inner()
             .schedule(
-                storage::Event::StorageRequest(StorageRequest::PutDeploy { deploy, responder }),
+                storage::Event::StorageRequest(Box::new(StorageRequest::PutDeploy { deploy, responder })),
                 QueueKind::Regular,
             )
             .ignore()

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -28,7 +28,7 @@ use super::{
 use crate::effect::EffectBuilder;
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 4, 6);
+    ProtocolVersion::from_parts(1, 4, 7);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -28,7 +28,7 @@ use super::{
 use crate::effect::EffectBuilder;
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 4, 7);
+    ProtocolVersion::from_parts(1, 4, 8);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 use std::net::{Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
 
 use casper_types::{ProtocolVersion, TimeDiff};
 use datasize::DataSize;
@@ -49,8 +50,22 @@ impl Default for Config {
             tarpit_chance: 0.2,
             max_in_flight_demands: 50,
             blocklist_retain_duration: TimeDiff::from_seconds(600),
+            identity: None,
         }
     }
+}
+
+/// Small network identity configuration.
+#[derive(DataSize, Debug, Clone, Deserialize, Serialize)]
+// Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
+#[serde(deny_unknown_fields)]
+pub struct IdentityConfig {
+    /// Path to a signed certificate
+    pub tls_certificate: PathBuf,
+    /// Path to a secret key.
+    pub secret_key: PathBuf,
+    /// Path to a certificate authority certificate
+    pub ca_certificate: PathBuf,
 }
 
 /// Small network configuration.
@@ -92,6 +107,11 @@ pub struct Config {
     pub max_in_flight_demands: u32,
     /// Duration peers are kept on the block list, before being redeemed.
     pub blocklist_retain_duration: TimeDiff,
+    /// Small network identity configuration option.
+    ///
+    /// An identity will be automatically generated when starting up a node if this option is
+    /// unspecified.
+    pub identity: Option<IdentityConfig>,
 }
 
 #[cfg(test)]

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 use crate::{
-    tls::ValidationError,
+    tls::{LoadCertError, ValidationError},
     utils::{LoadError, Loadable, ResolveAddressError},
 };
 
@@ -63,13 +63,26 @@ pub enum Error {
         #[source]
         ResolveAddressError,
     ),
-
     /// Instantiating metrics failed.
     #[error(transparent)]
     Metrics(
         #[serde(skip_serializing)]
         #[from]
         prometheus::Error,
+    ),
+    /// Failed to load a certificate.
+    #[error("failed to load a certificate: {0}")]
+    LoadCertificate(
+        #[serde(skip_serializing)]
+        #[from]
+        LoadCertError,
+    ),
+    /// Failed to validate a network CA certificate.
+    #[error("failed to validate a cert against network CA: {0:?}")]
+    CertValidationError(
+        #[serde(skip_serializing)]
+        #[source]
+        ValidationError,
     ),
 }
 

--- a/node/src/components/small_network/tasks.rs
+++ b/node/src/components/small_network/tasks.rs
@@ -206,7 +206,7 @@ where
     /// TLS certificate associated with this node's identity.
     pub(super) our_cert: Arc<TlsCert>,
     /// TLS certificate authority associated with this node's identity.
-    pub(super) our_ca: Option<Arc<X509>>,
+    pub(super) network_ca: Option<Arc<X509>>,
     /// Secret key associated with `our_cert`.
     pub(super) secret_key: Arc<PKey<Private>>,
     /// Weak reference to the networking metrics shared by all sender/receiver tasks.
@@ -235,7 +235,7 @@ where
 
 impl<REv> NetworkContext<REv> {
     pub(crate) fn validate_peer_cert(&self, peer_cert: X509) -> Result<TlsCert, ValidationError> {
-        match &self.our_ca {
+        match &self.network_ca {
             Some(ca_cert) => tls::validate_cert_with_authority(peer_cert, ca_cert),
             None => tls::validate_self_signed_cert(peer_cert),
         }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -185,7 +185,7 @@ impl Reactor for TestReactor {
         event_queue: EventQueueHandle<Self::Event>,
         _rng: &mut NodeRng,
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
-        let small_network_identity = SmallNetworkIdentity::new()?;
+        let small_network_identity = SmallNetworkIdentity::with_generated_certs()?;
         let (net, effects) = SmallNetwork::new(
             event_queue,
             cfg,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -204,11 +204,6 @@ pub(crate) enum Event {
     MarkBlockCompletedRequest(MarkBlockCompletedRequest),
 }
 
-#[test]
-fn size_test(){
-    println!("Event size is {}",_STORAGE_EVENT_SIZE);
-    const_assert!(_STORAGE_EVENT_SIZE <= 96);
-}
 
 
 impl Display for Event {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.6")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.7")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.4.7")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.4.8")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -232,8 +232,8 @@ impl Reactor {
 
         let effects = reactor::wrap_effects(Event::Chainspec, chainspec_effects);
 
-        let network_config = config.map_ref(|cfg| cfg.network.clone());
-        let small_network_identity = SmallNetworkIdentity::from_config(&network_config)?;
+        let network_config = config.map_ref(|config| config.network.clone());
+        let small_network_identity = SmallNetworkIdentity::from_config(network_config)?;
 
         let reactor = Reactor {
             config,

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -232,7 +232,8 @@ impl Reactor {
 
         let effects = reactor::wrap_effects(Event::Chainspec, chainspec_effects);
 
-        let small_network_identity = SmallNetworkIdentity::new()?;
+        let network_config = config.map_ref(|cfg| cfg.network.clone());
+        let small_network_identity = SmallNetworkIdentity::from_config(&network_config)?;
 
         let reactor = Reactor {
             config,

--- a/node/src/tls.rs
+++ b/node/src/tls.rs
@@ -287,8 +287,6 @@ pub(crate) enum LoadSecretKeyError {
 
 pub(crate) fn load_secret_key<P: AsRef<Path>>(src: P) -> Result<PKey<Private>, LoadSecretKeyError> {
     let pem = read_file(src.as_ref()).map_err(LoadSecretKeyError::ReadFile)?;
-
-    // TODO: It might be that we need to call `PKey::private_key_from_pkcs8` instead.
     PKey::private_key_from_pem(&pem).map_err(LoadSecretKeyError::PrivateKeyFromPem)
 }
 

--- a/node/src/utils/external.rs
+++ b/node/src/utils/external.rs
@@ -142,7 +142,7 @@ impl Loadable for X509 {
             Err(LoadCertError::ReadFile(error)) => {
                 anyhow::Error::new(error).context("failed to load certificate")
             }
-            Err(LoadCertError::X509(error)) => {
+            Err(LoadCertError::X509CertFromPem(error)) => {
                 anyhow::Error::new(error).context("parsing certificate")
             }
         };

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -194,6 +194,15 @@ tarpit_chance = 0.2
 # How long peers remain blocked after they get blacklisted.
 blocklist_retain_duration = '1min'
 
+# Identity of a node
+#
+# When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.
+# This option makes sense for some private chains where for security reasons joining new nodes is restricted.
+# [network.identity]
+# tls_certificate = "local_node_cert.pem"
+# secret_key = "local_node.pem"
+# ca_certificate = "ca_cert.pem"
+
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.
 #

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.6'
+version = '1.4.7'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.4.7'
+version = '1.4.8'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -194,6 +194,15 @@ tarpit_chance = 0.2
 # How long peers remain blocked after they get blacklisted.
 blocklist_retain_duration = '10min'
 
+# Identity of a node
+#
+# When this section is not specified, an identity will be generated when the node process starts with a self-signed certifcate.
+# This option makes sense for some private chains where for security reasons joining new nodes is restricted.
+# [network.identity]
+# tls_certificate = "node_cert.pem"
+# secret_key = "node.pem"
+# ca_certificate = "ca_cert.pem"
+
 # Weights for impact estimation of incoming messages, used in combination with
 # `max_incoming_message_rate_non_validators`.
 #

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -3861,7 +3861,7 @@
               "result": {
                 "name": "query_balance_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.8",
                   "balance": "123456"
                 }
               }
@@ -4156,7 +4156,7 @@
               "result": {
                 "name": "info_get_chainspec_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.8",
                   "chainspec_bytes": {
                     "chainspec_bytes": "2a2a",
                     "maybe_genesis_accounts_bytes": null,

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -3220,7 +3220,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.6"
+        "version": "1.4.7"
       },
       "methods": [
         {
@@ -3285,7 +3285,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -3343,7 +3343,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "deploy": {
                     "approvals": [
                       {
@@ -3532,7 +3532,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3615,7 +3615,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3705,7 +3705,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "cd502c5393a3c8b66d6979ad7857507c9baf5a8ba16ba99c28378d3a970fff42",
@@ -3924,7 +3924,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3969,7 +3969,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -4103,7 +4103,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -4206,7 +4206,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block": {
                     "body": {
                       "deploy_hashes": [],
@@ -4324,7 +4324,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                   "transfers": [
                     {
@@ -4408,7 +4408,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -4478,7 +4478,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -4568,7 +4568,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -4638,7 +4638,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,
@@ -4724,7 +4724,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.6",
+                  "api_version": "1.4.7",
                   "auction_state": {
                     "bids": [
                       {

--- a/resources/test/rpc_schema_hashing.json
+++ b/resources/test/rpc_schema_hashing.json
@@ -3220,7 +3220,7 @@
           "url": "https://raw.githubusercontent.com/CasperLabs/casper-node/master/LICENSE"
         },
         "title": "Client API of Casper Node",
-        "version": "1.4.7"
+        "version": "1.4.8"
       },
       "methods": [
         {
@@ -3285,7 +3285,7 @@
               "result": {
                 "name": "account_put_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "deploy_hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa"
                 }
               }
@@ -3343,7 +3343,7 @@
               "result": {
                 "name": "info_get_deploy_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "deploy": {
                     "approvals": [
                       {
@@ -3532,7 +3532,7 @@
                     "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
                     "named_keys": []
                   },
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
               }
@@ -3615,7 +3615,7 @@
               "result": {
                 "name": "state_get_dictionary_item_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "dictionary_key": "dictionary-67518854aa916c97d4e53df8570c8217ccc259da2721b692102d76acd0ee8d1f",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
@@ -3705,7 +3705,7 @@
               "result": {
                 "name": "query_global_state_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block_header": {
                     "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                     "body_hash": "cd502c5393a3c8b66d6979ad7857507c9baf5a8ba16ba99c28378d3a970fff42",
@@ -3924,7 +3924,7 @@
               "result": {
                 "name": "info_get_peers_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "peers": [
                     {
                       "address": "127.0.0.1:54321",
@@ -3969,7 +3969,7 @@
               "result": {
                 "name": "info_get_status_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "build_version": "1.0.0-xxxxxxxxx@DEBUG",
                   "chainspec_name": "casper-example",
                   "last_added_block_info": {
@@ -4103,7 +4103,7 @@
               "result": {
                 "name": "info_get_validator_changes_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "changes": [
                     {
                       "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
@@ -4206,7 +4206,7 @@
               "result": {
                 "name": "chain_get_block_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block": {
                     "body": {
                       "deploy_hashes": [],
@@ -4324,7 +4324,7 @@
               "result": {
                 "name": "chain_get_block_transfers_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                   "transfers": [
                     {
@@ -4408,7 +4408,7 @@
               "result": {
                 "name": "chain_get_state_root_hash_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
                 }
               }
@@ -4478,7 +4478,7 @@
               "result": {
                 "name": "state_get_item_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3",
                   "stored_value": {
                     "CLValue": {
@@ -4568,7 +4568,7 @@
               "result": {
                 "name": "state_get_balance_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "balance_value": "123456",
                   "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
                 }
@@ -4638,7 +4638,7 @@
               "result": {
                 "name": "chain_get_era_info_by_switch_block_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "era_summary": {
                     "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
                     "era_id": 42,
@@ -4724,7 +4724,7 @@
               "result": {
                 "name": "state_get_auction_info_example_result",
                 "value": {
-                  "api_version": "1.4.7",
+                  "api_version": "1.4.8",
                   "auction_state": {
                     "bids": [
                       {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.63"

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Library for developing Casper smart contracts.",
   "homepage": "https://docs.casperlabs.io/en/latest/dapp-dev-guide/index.html",
   "repository": {

--- a/smart_contracts/contracts/test/add-gas-subcall/src/main.rs
+++ b/smart_contracts/contracts/test/add-gas-subcall/src/main.rs
@@ -10,33 +10,33 @@ use casper_contract::contract_api::{runtime, storage};
 
 use casper_types::{
     runtime_args, ApiError, CLType, ContractHash, ContractVersion, EntryPoint, EntryPointAccess,
-    EntryPointType, EntryPoints, Parameter, RuntimeArgs,
+    EntryPointType, EntryPoints, Key, Parameter, RuntimeArgs,
 };
 
-// This is making use of the undocumented "FFI" function `gas()` which is used by the Wasm
-// interpreter to charge gas for upcoming interpreted instructions.  For further info on this, see
-// https://docs.rs/pwasm-utils/0.12.0/pwasm_utils/fn.inject_gas_counter.html
-mod unsafe_ffi {
-    extern "C" {
-        pub fn gas(amount: i32);
-    }
-}
-
-fn safe_gas(amount: i32) {
-    unsafe { unsafe_ffi::gas(amount) }
-}
-
 const SUBCALL_NAME: &str = "add_gas";
+const DATA_KEY: &str = "data";
 const ADD_GAS_FROM_SESSION: &str = "add-gas-from-session";
 const ADD_GAS_VIA_SUBCALL: &str = "add-gas-via-subcall";
 
 const ARG_GAS_AMOUNT: &str = "gas_amount";
 const ARG_METHOD_NAME: &str = "method_name";
 
+fn consume_gas(amount: i32) {
+    if amount > 0 {
+        let data = vec![0u8; amount as usize];
+        let data_uref = runtime::get_key(DATA_KEY)
+            .and_then(Key::into_uref)
+            .unwrap_or_else(|| storage::new_uref(()));
+
+        storage::write(data_uref, data);
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn add_gas() {
     let amount: i32 = runtime::get_named_arg(ARG_GAS_AMOUNT);
-    safe_gas(amount);
+
+    consume_gas(amount);
 }
 
 fn store() -> (ContractHash, ContractVersion) {
@@ -63,7 +63,7 @@ pub extern "C" fn call() {
     let method_name: String = runtime::get_named_arg(ARG_METHOD_NAME);
 
     match method_name.as_str() {
-        ADD_GAS_FROM_SESSION => safe_gas(amount),
+        ADD_GAS_FROM_SESSION => consume_gas(amount),
         ADD_GAS_VIA_SUBCALL => {
             let (contract_hash, _contract_version) = store();
             runtime::call_contract(


### PR DESCRIPTION
Changes:

- Reduced the size of the `storage.rs` Event enum from 96 total bytes to 32 bytes by wrapping `StorageRequest` and `StateStoreRequest` in Boxes.

 

- Additionally I updated 2 tests in `tests.rs` to reflect the new behavior required from using the boxes.