### PR TITLE
Event size reduction

### DIFF
--- a/node/src/components/deploy_acceptor/tests.rs
+++ b/node/src/components/deploy_acceptor/tests.rs
@@ -623,7 +623,10 @@ fn put_block_to_storage(
         effect_builder
             .into_inner()
             .schedule(
-                storage::Event::StorageRequest(StorageRequest::PutBlock { block, responder }),
+                storage::Event::StorageRequest(Box::new(StorageRequest::PutBlock {
+                    block,
+                    responder,
+                })),
                 QueueKind::Regular,
             )
             .ignore()
@@ -638,7 +641,10 @@ fn put_deploy_to_storage(
         effect_builder
             .into_inner()
             .schedule(
-                storage::Event::StorageRequest(StorageRequest::PutDeploy { deploy, responder }),
+                storage::Event::StorageRequest(Box::new(StorageRequest::PutDeploy {
+                    deploy,
+                    responder,
+                })),
                 QueueKind::Regular,
             )
             .ignore()

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -226,10 +226,7 @@ pub(crate) enum Event {
     #[from]
     MarkBlockCompletedRequest(BlockCompleteConfirmationRequest),
 }
-#[test]
-fn size_test() {
-    println!("{}", mem::size_of::<AppStateRequest>());
-}
+
 impl Display for Event {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -247,12 +244,14 @@ impl From<NetRequestIncoming> for Event {
         Event::NetRequestIncoming(Box::new(incoming))
     }
 }
+
 impl From<StorageRequest> for Event {
     #[inline]
     fn from(request: StorageRequest) -> Self {
         Event::StorageRequest(Box::new(request))
     }
 }
+
 impl From<AppStateRequest> for Event {
     #[inline]
     fn from(request: AppStateRequest) -> Self {


### PR DESCRIPTION
Changes:

- Reduced the size of the `storage.rs` Event enum from 96 total bytes to 32 bytes by wrapping `StorageRequest` and `StateStoreRequest` in Boxes.

 

- Additionally I updated 2 tests in `tests.rs` to reflect the new behavior required from using the boxes.