### PR TITLE
Fix signature validation in blocks without transactions

### DIFF
--- a/node/src/components/block_validator/state.rs
+++ b/node/src/components/block_validator/state.rs
@@ -125,7 +125,7 @@ impl BlockValidationState {
         chainspec: &Chainspec,
     ) -> (Self, Option<Responder<bool>>) {
         let transaction_count = block.non_transfer_count() + block.transfer_count();
-        if transaction_count == 0 {
+        if transaction_count == 0 && missing_signatures.is_empty() {
             let state = BlockValidationState::Valid(block.timestamp());
             return (state, Some(responder));
         }


### PR DESCRIPTION
This fixes an issue in `BlockValidator` and adds a regression test.
